### PR TITLE
Add a hover for buttons and change the price background at the same time

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import styles from './ProductBox.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -5,6 +5,13 @@
   border: 1px solid #e1e1e1;
   margin-bottom: 2rem;
 
+  &:hover .photo .buttons {
+    visibility: visible;
+  }
+  &:hover .actions div:last-child {
+    background-color: $primary;
+  }
+
   .photo {
     position: relative;
     padding: 80% 10px 0 10px;
@@ -31,6 +38,7 @@
     .buttons {
       display: flex;
       justify-content: space-between;
+      visibility: hidden;
     }
   }
 


### PR DESCRIPTION
Problem:
Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 

Rozwiązanie:
W ProductBox.module.scss dodanie na główny hover boksa (.root) pokazania się przycisków na hover (ukrycie ich na początku) oraz dodanie kolejnego na zmianę koloru tła ceny na diva z ostatnim dzieckiem (z tym miałem problem).