### PR TITLE
WDP231003-62

### DIFF
--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { NavLink } from 'react-router-dom';
 
 import ProductSearch from '../../features/ProductSearch/ProductSearch';
 
@@ -19,24 +20,51 @@ const MenuBar = ({ children }) => (
               <Navbar.Collapse id='basic-navbar-nav' className='p-0'>
                 <Nav className='me-auto'>
                   <Nav.Link
-                    href='/'
-                    className={`px-4 ${styles.active} ${styles.nav}`}
+                    as={NavLink}
+                    to='/'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
                   >
                     Home
                   </Nav.Link>
-                  <Nav.Link href='/shop/furniture' className={'px-4 ' + styles.nav}>
+                  <Nav.Link
+                    as={NavLink}
+                    to='/shop/furniture'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
+                  >
                     Furniture
                   </Nav.Link>
-                  <Nav.Link href='/shop/chair' className={'px-4 ' + styles.nav}>
+                  <Nav.Link
+                    as={NavLink}
+                    to='/shop/chair'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
+                  >
                     Chair
                   </Nav.Link>
-                  <Nav.Link href='/shop/table' className={'px-4 ' + styles.nav}>
+                  <Nav.Link
+                    as={NavLink}
+                    to='/shop/table'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
+                  >
                     Table
                   </Nav.Link>
-                  <Nav.Link href='/shop/bedroom' className={'px-4 ' + styles.nav}>
+                  <Nav.Link
+                    as={NavLink}
+                    to='/shop/bedroom'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
+                  >
                     Bedroom
                   </Nav.Link>
-                  <Nav.Link href='/blog' className={'px-4 ' + styles.nav}>
+                  <Nav.Link
+                    as={NavLink}
+                    to='/blog'
+                    className={'px-4 ' + styles.nav}
+                    activeClassName={styles.active}
+                  >
                     Blog
                   </Nav.Link>
                 </Nav>

--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
 import ProductSearch from '../../features/ProductSearch/ProductSearch';
 
@@ -9,76 +9,80 @@ import Container from 'react-bootstrap/Container';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 
-const MenuBar = ({ children }) => (
-  <div className={styles.root}>
-    <div className='container'>
-      <div className='row flex-lg-reverse flex-xl-row-reverse'>
-        <div className={'col ' + styles.menu}>
-          <Navbar expand='md' className='bg-body-tertiary p-0'>
-            <Container className='px-0'>
-              <Navbar.Toggle aria-controls='basic-navbar-nav' />
-              <Navbar.Collapse id='basic-navbar-nav' className='p-0'>
-                <Nav className='me-auto'>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Home
-                  </Nav.Link>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/shop/furniture'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Furniture
-                  </Nav.Link>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/shop/chair'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Chair
-                  </Nav.Link>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/shop/table'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Table
-                  </Nav.Link>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/shop/bedroom'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Bedroom
-                  </Nav.Link>
-                  <Nav.Link
-                    as={NavLink}
-                    to='/blog'
-                    className={'px-4 ' + styles.nav}
-                    activeClassName={styles.active}
-                  >
-                    Blog
-                  </Nav.Link>
-                </Nav>
-              </Navbar.Collapse>
-            </Container>
-          </Navbar>
-        </div>
-        <div className='col d-flex align-items-center'>
-          <ProductSearch />
+const MenuBar = ({ children }) => {
+  const location = useLocation();
+
+  return (
+    <div className={styles.root}>
+      <div className='container'>
+        <div className='row flex-lg-reverse flex-xl-row-reverse'>
+          <div className={'col ' + styles.menu}>
+            <Navbar expand='md' className='bg-body-tertiary p-0'>
+              <Container className='px-0'>
+                <Navbar.Toggle aria-controls='basic-navbar-nav' />
+                <Navbar.Collapse id='basic-navbar-nav' className='p-0'>
+                  <Nav className='me-auto'>
+                    <NavLink
+                      to='/'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                      isActive={() => location.pathname === '/'}
+                    >
+                      Home
+                    </NavLink>
+                    <Nav.Link
+                      as={NavLink}
+                      to='/shop/furniture'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                    >
+                      Furniture
+                    </Nav.Link>
+                    <Nav.Link
+                      as={NavLink}
+                      to='/shop/chair'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                    >
+                      Chair
+                    </Nav.Link>
+                    <Nav.Link
+                      as={NavLink}
+                      to='/shop/table'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                    >
+                      Table
+                    </Nav.Link>
+                    <Nav.Link
+                      as={NavLink}
+                      to='/shop/bedroom'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                    >
+                      Bedroom
+                    </Nav.Link>
+                    <Nav.Link
+                      as={NavLink}
+                      to='/blog'
+                      className={'px-4 ' + styles.nav}
+                      activeClassName={styles.active}
+                    >
+                      Blog
+                    </Nav.Link>
+                  </Nav>
+                </Navbar.Collapse>
+              </Container>
+            </Navbar>
+          </div>
+          <div className='col d-flex align-items-center'>
+            <ProductSearch />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 MenuBar.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
Ticket utworzony przeze mnie

Problem:
Aktualnie style aktywnej karty są na sztywno przypisane do HOME, trzeba to poprawić tak, żeby na pomarańczowo podświetlał się aktywny kafelek przypisany do aktualnie otwartej podstrony. Dodatkowo kliknięcie linka przeładowuje całą stronę, trzeba to naprawić

Rozwiązanie:
Użycie Navlink, żeby zapobiec przeładowaniu strony i nadać aktywną klasę. Dodatkowo był problem z podstroną HOME, która po tej zmianie nadal zawsze miała klasę active. Prawdopodobnie wynikało to z użycia "exact path". Można by to było rozwiązać zmieniając w App Switch na Routes, ale wersja react-router-dom na to nie pozwalała. Dlatego w MenuBar użyłam useLocation